### PR TITLE
'disabled' newer/older links cannot be interacted with

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -111,7 +111,8 @@ section {
   text-decoration: underline; }
 .items a.page.empty {
   color: #969499;
-  text-decoration: none; }
+  text-decoration: none;
+  cursor: default; }
 
 .item {
   padding: 8px 36;

--- a/static/sass/items.scss
+++ b/static/sass/items.scss
@@ -26,6 +26,7 @@ section {
 	a.page.empty {
 		color: $midgray;
 		text-decoration: none;
+		cursor: default;
 	}
 }
 

--- a/templates/items/section.html
+++ b/templates/items/section.html
@@ -7,16 +7,16 @@
   {% endfor %}
   {% if items.has_next %}
     <a class="page" href="?{{ pagination_key }}={{ items.next_page_number }}">
-      Older &rarr; 
+      Older &rarr;
     </a>
   {% else %}
-    <a class="page empty" href="#">Older &rarr;</a>
+    <a class="page empty">Older &rarr;</a>
   {% endif %}
   {% if items.has_previous %}
     <a class="page" href="?{{ pagination_key }}={{ items.previous_page_number }}">
       &larr; Newer
     </a>
   {% else %}
-    <a class="page empty" href="#">&larr; Newer</a>
+    <a class="page empty">&larr; Newer</a>
   {% endif %}
 </div>


### PR DESCRIPTION
This fixes two separate, but related UX issues with the "Newer"/"Older" navigation links when they are "disabled" (or `empty`):
- clicking on either jumps to the top of the page
- a pointer cursor is used, making them appear operable

I did not just remove the `href` attribute, as that gave the text selection cursor, which seems undesirable. This is why I explicitly used `cursor: default`.